### PR TITLE
BUG/MINOR: run.sh: Update sed to be portable with GNU sed

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -54,7 +54,14 @@ fi
 filename=$directory"/report_$(date +%s).json"
 
 nuclei -no-interactsh -disable-update-check -config $config -u $target -irr -json > $filename
-sed -i '' 's/}$/,"wafVersion":"'${wafVersion}'","nucleiVersion":"'${nucleiVersion}'","payloadVersion":"'${payloadVersion:="0"}'"}/g' $filename
+
+# check if we are using gnu sed
+# if not, then -i requires passing an empty extension
+if sed v < /dev/null 2> /dev/null;  then
+    sed -i 's/}$/,"wafVersion":"'${wafVersion}'","nucleiVersion":"'${nucleiVersion}'","payloadVersion":"'${payloadVersion:="0"}'"}/g' $filename
+else
+    sed -i '' 's/}$/,"wafVersion":"'${wafVersion}'","nucleiVersion":"'${nucleiVersion}'","payloadVersion":"'${payloadVersion:="0"}'"}/g' $filename
+fi
 
 if [ "$wafResponse" ]; then
     python3 score.py -f $filename -r "$wafResponse"

--- a/run.sh
+++ b/run.sh
@@ -55,8 +55,7 @@ filename=$directory"/report_$(date +%s).json"
 
 nuclei -no-interactsh -disable-update-check -config $config -u $target -irr -json > $filename
 
-# check if we are using gnu sed
-# if not, then -i requires passing an empty extension
+# check if using GNU sed, if not then -i requires passing an empty extension
 if sed v < /dev/null 2> /dev/null;  then
     sed -i 's/}$/,"wafVersion":"'${wafVersion}'","nucleiVersion":"'${nucleiVersion}'","payloadVersion":"'${payloadVersion:="0"}'"}/g' $filename
 else


### PR DESCRIPTION
Currently, sed is called with the in-place replacement argument (-i).
This argument acts differently in GNU sed and outputs the following
error:

sed: can't read s/}$/,"wafVersion":"","nucleiVersion":"2.5.5","payloadVersion":"0"}/g: No such file or directory

This due to the empty extension being passed, which is being interpreted
as the pattern and the pattern is then being pushed into the file position.

There are several ways to handle this situation but I chose to do it using the
`sed v` command as within the GNU manual for sed [1] it explicitly calls out
that "it does nothing, but makes sed fail if GNU sed extrensions are not supported".

[1] https://www.gnu.org/software/sed/manual/html_node/sed-commands-list.html