### PR TITLE
Draft: port to go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module wafefficacy
+
+go 1.18

--- a/main.go
+++ b/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+func main() {
+	// Options with shorthand names (trying to keep same names as nuclei's)
+	var target string
+	var verbose bool
+
+	// Options
+	flag.StringVar(&target, "target", "", "target URL/host to scan")
+	flag.StringVar(&target, "u", "", "target URL/host to scan (shorthand)")
+	config := flag.String("config", "nuclei/config.yaml", "path to the nuclei configuration file")
+	blockedResponse := flag.String("r", "406 Not Acceptable", "waf response for blocked requests")
+	flag.BoolVar(&verbose, "verbose", false, "verbose")
+	flag.BoolVar(&verbose, "v", false, "verbose (shorthand)")
+
+	// TODO: make an option
+	attackTypes := []string{"cmdexe", "sqli", "traversal", "xss"}
+
+	flag.Parse()
+
+	if target == "" {
+		fmt.Printf("Error: must specify target url with --target or -u\n")
+		os.Exit(1)
+	}
+
+	nucleiVersion, err := GetNucleiVersion()
+	if err != nil {
+		fmt.Println("Can't find nuclei", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Running efficacy tests using Nuclei version", nucleiVersion)
+	nucleiOutput, err := RunNuclei(*config, target, verbose)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	nr, err := ReadResults(nucleiOutput, *blockedResponse, attackTypes)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	nr.PrintScore()
+
+	err = nr.PrintJSONResults()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/wafefficacy.go
+++ b/wafefficacy.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// GetNucleiVersion runs Nuclei --version, and returns the reported version.
+func GetNucleiVersion() (string, error) {
+	out, err := exec.Command("nuclei", "--version").CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	// TODO: use a capture group for the version instead
+	versionRegex := regexp.MustCompile(`(?s)^.*Version: `)
+	buf := string(out)
+	nucleiVersion := versionRegex.ReplaceAllString(buf, "")
+	return nucleiVersion, nil
+}
+
+// RunNuclei runs Nuclei with the given config, and returns a stream of its output.
+func RunNuclei(config string, target string, verbose bool) (r io.Reader, err error) {
+	args := []string{
+		"-no-interactsh",
+		"-config", config,
+		"-u", target,
+		"-irr",
+		"-json",
+	}
+	if verbose {
+		// TODO: figure out where the verbose output goes... probably stderr, which we don't capture
+		args = append(args, "-v")
+	}
+	cmd := exec.Command("nuclei", args...)
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err = cmd.Run()
+	if err != nil {
+		return r, err
+	}
+
+	return &out, err
+}
+
+// NucleiResults holds the results of a Nuclei run.
+type NucleiResults struct {
+	blockedResponse string
+	attackTypes     []string
+	results         []ScanResult
+}
+
+// ReadResults takes the stream of output from RunNuclei and a few other arguments, and returns a NucleiResults.
+func ReadResults(nucleiOutput io.Reader, blockedResponse string, attackTypes []string) (nr NucleiResults, err error) {
+	nr.blockedResponse = blockedResponse
+	nr.attackTypes = attackTypes
+	nr.results, err = readJSON(nucleiOutput)
+	return nr, err
+}
+
+// ScanResult is the set of fields of the nuclei json output we care about
+type ScanResult struct {
+	TemplateID string `json:"template-id"`
+	Info       struct {
+		Name        string   `json:"name"`
+		Author      []string `json:"author"`
+		Tags        []string `json:"tags"`
+		Description string   `json:"description"`
+	} `json:"info"`
+	Type     string `json:"type"`
+	Request  string `json:"request"`
+	Response string `json:"response"`
+	Curl     string `json:"curl-command"`
+}
+
+// readJSON reads nuclei's output and sorts it so the json output can be compared with 'diff', such that identical results show no output
+func readJSON(results io.Reader) (w []ScanResult, err error) {
+	scanner := bufio.NewScanner(results)
+	for scanner.Scan() {
+		var scanResult ScanResult
+		err := json.Unmarshal([]byte(scanner.Text()), &scanResult)
+		if err != nil {
+			return nil, err
+		}
+		w = append(w, scanResult)
+	}
+	sort.Slice(w, func(i, j int) bool {
+		if w[i].TemplateID != w[j].TemplateID {
+			return w[i].TemplateID < w[j].TemplateID
+		}
+		return w[i].Request < w[j].Request
+	})
+
+	return w, err
+}
+
+func (nr *NucleiResults) isBlocked(response string) bool {
+	return strings.Contains(response, nr.blockedResponse)
+}
+
+func (nr *NucleiResults) truePositivesFalseNegatives(attackType string) (truePositives, falseNegatives int) {
+	for _, result := range nr.results {
+		if result.TemplateID == attackType+"-true-positive" {
+			if nr.isBlocked(result.Response) {
+				truePositives += 1
+			} else {
+				falseNegatives += 1
+			}
+		}
+	}
+	return truePositives, falseNegatives
+}
+
+func (nr *NucleiResults) trueNegativesFalsePositives(attackType string) (trueNegatives, falsePositives int) {
+	for _, result := range nr.results {
+		if result.TemplateID == attackType+"-false-positive" {
+			if nr.isBlocked(result.Response) {
+				falsePositives += 1
+			} else {
+				trueNegatives += 1
+			}
+		}
+	}
+	return trueNegatives, falsePositives
+}
+
+// PrintScore calculates the score, both overall and by attack type, and prints it to stdout.
+func (nr *NucleiResults) PrintScore() {
+	truePositives := 0
+	falseNegatives := 0
+	trueNegatives := 0
+	falsePositives := 0
+
+	for _, attackType := range nr.attackTypes {
+		tp, fn := nr.truePositivesFalseNegatives(attackType)
+		tn, fp := nr.trueNegativesFalsePositives(attackType)
+		truePositives += tp
+		falseNegatives += fn
+		trueNegatives += tn
+		falsePositives += fp
+		fmt.Println("-------------" + strings.ToUpper(attackType) + "-------------")
+		fmt.Println("True Positives", tp)
+		fmt.Println("False Negatives", fn)
+		fmt.Println("True Negatives", tn)
+		fmt.Println("False Positives", fp)
+		sensitivity := float64(tp) / float64(tp+fn)
+		specificity := float64(tn) / float64(tn+fp)
+		balanced_accuracy := (sensitivity + specificity) / 2
+		efficacyScore := balanced_accuracy * 100
+		fmt.Printf("Efficacy %.3f\n", efficacyScore)
+	}
+
+	fmt.Println("------------- WAF Efficacy -------------")
+	sensitivity := float64(truePositives) / float64(truePositives+falseNegatives)
+	specificity := float64(trueNegatives) / float64(trueNegatives+falsePositives)
+	balanced_accuracy := (sensitivity + specificity) / 2
+	efficacyScore := balanced_accuracy * 100
+	fmt.Printf("Overall efficacy: %.3f\n", efficacyScore)
+}
+
+// PrintJSONResults formats the results as a subset of Nuclei's own JSON output, but sorted and diffable, and saves them in a timestamped file.
+func (nr *NucleiResults) PrintJSONResults() error {
+	// TODO: put it in the right directory/file
+	w, err := os.Create("data.json")
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+
+	for _, result := range nr.results {
+		b, err := json.Marshal(result)
+		if err != nil {
+			return err
+		}
+		line := fmt.Sprintln(string(b))
+		_, err = w.WriteString(line)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
wafefficacy is cool, but is written in a mix of shell and python, which makes it harder to install and use. Pure go is likely more portable, and may simplify later enhancements.

Along the way, added these enhancements^Wpersonal preferences:
- make output json diffable
- omit less uninteresting fields from output json
- make options and output files a bit more like nuclei's
- drop the cloud log feature for the moment

TODO:
- add tests
- put json output in right place
- make -v work
- add back assertion files
- add back cloud log feature as shell script wrapper?