### PR TITLE
Fix missing url encoding in traversal/true-positive.yaml?

### DIFF
--- a/nuclei/templates/cmdexe/true-positive.yaml
+++ b/nuclei/templates/cmdexe/true-positive.yaml
@@ -9,15 +9,15 @@ info:
 requests:
   - payloads:
       cmdexe: nuclei/payloads/cmdexe/true-positives.txt
-      
+
     raw:
       - |
-        GET /?p={{url_encode(cmdexe)}} HTTP/1.1
+        GET /anything?p={{url_encode(cmdexe)}} HTTP/1.1
         Host: {{Hostname}}
         Connection: close
 
       - |
-        POST / HTTP/1.1
+        POST /anything HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
         Connection: close

--- a/nuclei/templates/traversal/true-positive.yaml
+++ b/nuclei/templates/traversal/true-positive.yaml
@@ -12,7 +12,7 @@ requests:
 
     raw:
       - |
-        GET /anything?p={{traversal}} HTTP/1.1
+        GET /anything?p={{url_encode(traversal)}} HTTP/1.1
         Host: {{Hostname}}
         Connection: close
       


### PR DESCRIPTION
Also use same path in cmdexe/*-positive.yaml.

Spotted with diff.  As yet untested...