### PR TITLE
Updated nuclei command for json export

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -78,7 +78,7 @@ fi
 # add timestamp to filename
 filename="$reportPath/report_$(date +%s).json"
 
-nuclei -no-interactsh -disable-update-check -stats -config $config -u $target -irr -json $verbose > $filename
+nuclei -no-interactsh -disable-update-check -stats -config $config -u $target -irr -jsonl $verbose > $filename
 
 # check if using GNU sed, if not then -i requires passing an empty extension
 if sed v < /dev/null 2> /dev/null;  then


### PR DESCRIPTION
I was getting a JSON decoding error when attempting to run the tool, upon further investigation I noticed that the nuclei command used `-json` for output when the documentation for nuclei shows that you need `-jsonl` for the JSON output